### PR TITLE
fix: return pointer when filtering a slice of pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.2.1](https://github.com/flusflas/dipper/tree/v0.2.1) (2024-06-14)
+
+### Fixed
+
+- The result of filtering a slice of pointers returned a non-pointer element.
+
+
 ## [v0.2.0](https://github.com/flusflas/dipper/tree/v0.2.0) (2024-05-26)
 
 ### Added

--- a/dipper_test.go
+++ b/dipper_test.go
@@ -237,6 +237,16 @@ func TestDipper_Get(t *testing.T) {
 			want: "Crime",
 		},
 		{
+			name: "slice of pointers should return a pointer",
+			args: args{
+				obj: []*Book{
+					getTestStruct(),
+				},
+				attribute: "[0]",
+			},
+			want: getTestStruct(),
+		},
+		{
 			name: "slice using brackets notation after separator",
 			args: args{
 				obj:       getTestStruct(),

--- a/filter.go
+++ b/filter.go
@@ -81,26 +81,27 @@ func filterSlice(value reflect.Value, fieldName string) (reflect.Value, error) {
 
 	// Iterates over the value elements and returns the first matching value
 	for i := 0; i < value.Len(); i++ {
-		item := getElemSafe(value.Index(i))
+		item := value.Index(i)
+		itemSafe := getElemSafe(item)
 
-		switch item.Kind() {
+		switch itemSafe.Kind() {
 		case reflect.Map:
-			for _, mapKey := range item.MapKeys() {
+			for _, mapKey := range itemSafe.MapKeys() {
 				if mapKey.String() != filterKey {
 					continue
 				}
 
-				if compareValues(item.MapIndex(mapKey)) {
+				if compareValues(itemSafe.MapIndex(mapKey)) {
 					return item, nil
 				}
 			}
 		case reflect.Struct:
-			for i := 0; i < item.NumField(); i++ {
-				if item.Type().Field(i).Name != filterKey {
+			for i := 0; i < itemSafe.NumField(); i++ {
+				if itemSafe.Type().Field(i).Name != filterKey {
 					continue
 				}
 
-				field := item.Field(i)
+				field := itemSafe.Field(i)
 				if compareValues(field) {
 					return item, nil
 				}

--- a/filter_test.go
+++ b/filter_test.go
@@ -98,6 +98,16 @@ func TestDipper_GetWithFilter(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "slice of pointers should return a pointer",
+			args: args{
+				obj: []*Book{
+					getTestStruct(),
+				},
+				attribute: "[Year=1980]",
+			},
+			want: getTestStruct(),
+		},
+		{
 			name: "invalid filter expression",
 			args: args{
 				obj:       getTestStruct(),


### PR DESCRIPTION
This PR fixes a bug when filtering a slice of pointers, which returned non-pointer elements.